### PR TITLE
Fix value of $plugin->incompatible property to be an integer

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,6 +28,6 @@ $plugin->component = 'quizaccess_wifiresilience';
 $plugin->version = 2024022601;
 $plugin->requires = 2022112800; // Moodle 4.1.
 $plugin->supported = [400, 401];
-$plugin->incompatible = [402];
+$plugin->incompatible = 402;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.1';


### PR DESCRIPTION
The value of the `$plugin->incompatible` property needs to be an integer (see https://moodledev.io/docs/apis/commonfiles/version.php#incompatible-versions)
If not it breaks the plugin when trying to install it.