### PR TITLE
Fix directory

### DIFF
--- a/thirdpartylibs.xml
+++ b/thirdpartylibs.xml
@@ -15,7 +15,7 @@
     <licenseversion></licenseversion>
   </library>
   <library>
-    <location>js/workbox/js</location>
+    <location>js/workbox</location>
     <name>Workbox SW</name>
     <license>Apache</license>
     <version>1.0</version>


### PR DESCRIPTION
grunt is complaining:

Running "ignorefiles" task
Warning: ENOENT: no such file or directory, stat 'mod/quiz/accessrule/wifiresilience/js/workbox/js' Use --force to continue.

This is due to a wrong directory in thirdpartylibs.xml